### PR TITLE
docs: add CONTRIBUTING.md with guidelines and conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Thank you for your interest in contributing to `dot15d4`! We welcome pull requests, issues, suggestions, and discussions to help improve the project.
+
+This document outlines how to contribute to this repository and the guidelines we follow to maintain a consistent and high-quality codebase.
+
+## Getting Started
+
+1. **Fork the repository** and create a branch from `main`.
+2. Make your changes.
+3. Ensure all tests pass and code is formatted correctly (default `cargo fmt` formatting).
+4. Commit your changes following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+5. Push your branch and open a **pull request**.
+
+## Code of Conduct
+
+We follow the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct). By participating in this project, you agree to abide by its terms.
+
+## Questions and Discussions
+
+For broader discussions, ideas, or questions, open an issue labeled as a question.
+
+Thank you for helping make dot15d4 better! 🧡


### PR DESCRIPTION
Introduce CONTRIBUTING.md to outline contribution steps, code formatting, commit message conventions, and the Rust Code of Conduct. Also provides instructions for asking questions and opening discussions to support new contributors.