### PR TITLE
feat(frame): add safety checks to MpduFrame::new

### DIFF
--- a/dot15d4-frame/src/fields/mpdu.rs
+++ b/dot15d4-frame/src/fields/mpdu.rs
@@ -171,7 +171,9 @@ impl<'repr> MpduRepr<'repr, MpduWithIes> {
         assert!(buffer.len() >= min_buffer_length as usize);
 
         let offset_mpdu = radio_frame_repr.headroom_length();
-        let mut mpdu = MpduFrame::new(buffer, offset_mpdu, mpdu_length_wo_fcs);
+        // Safety: we already asserted that the buffer is large enough to hold the minimum
+        // calculated MPDU length.
+        let mut mpdu = unsafe { MpduFrame::new(buffer, offset_mpdu, mpdu_length_wo_fcs) };
 
         let (dst_addr_mode, src_addr_mode, pan_id_compression) = match &self.addressing {
             Some(addressing) => (

--- a/dot15d4-frame/src/mpdu/frame.rs
+++ b/dot15d4-frame/src/mpdu/frame.rs
@@ -22,7 +22,22 @@ pub struct MpduFrame {
 }
 
 impl MpduFrame {
-    pub fn new(buffer: BufferToken, offset: u8, length_wo_fcs: NonZero<u16>) -> Self {
+    /// Creates a new unparsed MPDU frame.
+    ///
+    /// # Safety
+    ///
+    /// 1. Incoming frames must always be backed by a `buffer` that is at least
+    ///    [`RadioFrameRepr::max_buffer_length()`] bytes long. This is because we don't know
+    ///    the length of the MPDU at this point, so we assume the maximum length.
+    /// 2. Outgoing frames must always be backed by a `buffer` that can at least hold the smallest
+    ///    MPDU, which is the immediate acknowledgment (ACK) frame.
+    ///
+    /// These conditions are not checked at runtime, so it is the caller's
+    /// responsibility to ensure that the buffer is large enough.
+    ///
+    /// [`RadioFrameRepr::max_buffer_length()`]:
+    /// dot15d4_driver::frame::RadioFrameRepr::max_buffer_length
+    pub unsafe fn new(buffer: BufferToken, offset: u8, length_wo_fcs: NonZero<u16>) -> Self {
         Self {
             buffer,
             offset,


### PR DESCRIPTION
Add debug assertions in `MpduFrame::new` to ensure the buffer is large enough and the frame length is at least 3 bytes.